### PR TITLE
1.18.2- Re-enabled Patchouli integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    // useApi "vazkii.patchouli:Patchouli:1.17-${project.patchouli_version}"
+    useApi "vazkii.patchouli:Patchouli:1.18.2-${project.patchouli_version}"
     println "Using local BCLib: ${local_bclib}"
     if (local_bclib){		
         implementation( project(path:":BCLib", configuration: 'dev') )

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ archives_base_name=better-end
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 
-patchouli_version = 55-FABRIC-SNAPSHOT
+patchouli_version = 69-FABRIC
 bclib_version = 1.4.3
 rei_version = 8.0.442
 canvas_version = 1.0.+

--- a/src/main/java/ru/betterend/item/GuideBookItem.java
+++ b/src/main/java/ru/betterend/item/GuideBookItem.java
@@ -15,6 +15,7 @@ import ru.bclib.items.ModelProviderItem;
 import ru.betterend.BetterEnd;
 import ru.betterend.registry.EndItems;
 import ru.betterend.util.LangUtil;
+import vazkii.patchouli.api.PatchouliAPI;
 
 import java.util.List;
 
@@ -32,8 +33,8 @@ public class GuideBookItem extends ModelProviderItem {
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level world, Player user, InteractionHand hand) {
 		if (!world.isClientSide && user instanceof ServerPlayer) {
-			//TODO: reanable Patchouli once it is available for 1.18
-			//PatchouliAPI.get().openBookGUI((ServerPlayer) user, BOOK_ID);
+			
+			PatchouliAPI.get().openBookGUI((ServerPlayer) user, BOOK_ID);
 			return InteractionResultHolder.success(user.getItemInHand(hand));
 		}
 		return InteractionResultHolder.consume(user.getItemInHand(hand));


### PR DESCRIPTION
Simply uncommented a couple of lines and updated maven URL and Patchouli version.

Now you can open the guidebook and see the rituals (and possible future content) again.