### PR TITLE
Krypton infusion pedestal fix

### DIFF
--- a/src/main/java/org/betterx/betterend/blocks/InfusionPedestal.java
+++ b/src/main/java/org/betterx/betterend/blocks/InfusionPedestal.java
@@ -84,7 +84,7 @@ public class InfusionPedestal extends PedestalBlock {
             BlockState blockState,
             BlockEntityType<T> blockEntityType
     ) {
-        return InfusionPedestalEntity::tickEnity;
+        return InfusionPedestalEntity::tickEntity;
     }
 
     static {

--- a/src/main/java/org/betterx/betterend/blocks/entities/InfusionPedestalEntity.java
+++ b/src/main/java/org/betterx/betterend/blocks/entities/InfusionPedestalEntity.java
@@ -52,13 +52,15 @@ public class InfusionPedestalEntity extends PedestalBlockEntity {
     protected void fromTag(CompoundTag tag) {
         super.fromTag(tag);
         if (tag.contains("ritual")) {
-            linkedRitual = new InfusionRitual(this, level, worldPosition);
+            if (!hasRitual()) {
+                linkedRitual = new InfusionRitual(this, level, worldPosition);
+            }
             linkedRitual.fromTag(tag.getCompound("ritual"));
             linkedRitual.configure();
         }
     }
 
-    public static <T extends BlockEntity> void tickEnity(
+    public static <T extends BlockEntity> void tickEntity(
             Level level,
             BlockPos blockPos,
             BlockState blockState,

--- a/src/main/java/org/betterx/betterend/rituals/InfusionRitual.java
+++ b/src/main/java/org/betterx/betterend/rituals/InfusionRitual.java
@@ -16,6 +16,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.LevelChunk.EntityCreationType;
 import net.minecraft.world.phys.Vec3;
 
 import java.awt.*;
@@ -56,7 +57,9 @@ public class InfusionRitual implements Container {
         for (int i = 0; i < catalysts.length; i++) {
             Point point = PEDESTALS_MAP[i];
             MutableBlockPos checkPos = worldPos.mutable().move(Direction.EAST, point.x).move(Direction.NORTH, point.y);
-            BlockEntity catalystEntity = world.getBlockEntity(checkPos);
+            BlockEntity catalystEntity = world.isClientSide
+                    ? world.getChunkAt(checkPos).getBlockEntity(checkPos, EntityCreationType.CHECK)
+                    : world.getBlockEntity(checkPos);
             if (catalystEntity instanceof PedestalBlockEntity) {
                 catalysts[i] = (PedestalBlockEntity) catalystEntity;
             } else {


### PR DESCRIPTION
Steps to reproduce: 

1. Add [Krypton](https://www.curseforge.com/minecraft/mc-mods/krypton) mod (version 0.2.1 at the moment).
2. Place two or more infusion pedestals. At least one has to be in the position of a catalyst. Like this:
![2022-10-27_02 36 16](https://user-images.githubusercontent.com/2053667/198165329-03b5670c-75d4-4ff8-8a82-26a31d6c2abc.png)
3. Exit and re-enter.
4. Gets an infinite recursion, crashes with StackOverflowError.


Fixes quiqueck/BetterEnd#101.