### PR TITLE
Disabling end entities fix.

### DIFF
--- a/src/main/java/org/betterx/betterend/blocks/SilkMothHiveBlock.java
+++ b/src/main/java/org/betterx/betterend/blocks/SilkMothHiveBlock.java
@@ -82,13 +82,13 @@ public class SilkMothHiveBlock extends BaseBlock {
         if (!world.getBlockState(spawn).isAir()) {
             return;
         }
-        int count = world.getEntities(EndEntities.SILK_MOTH, new AABB(pos).inflate(16), (entity) -> {
+        int count = world.getEntities(EndEntities.SILK_MOTH.type(), new AABB(pos).inflate(16), (entity) -> {
             return true;
         }).size();
         if (count > 6) {
             return;
         }
-        SilkMothEntity moth = new SilkMothEntity(EndEntities.SILK_MOTH, world);
+        SilkMothEntity moth = new SilkMothEntity(EndEntities.SILK_MOTH.type(), world);
         moth.moveTo(spawn.getX() + 0.5, spawn.getY() + 0.5, spawn.getZ() + 0.5, dir.toYRot(), 0);
         moth.setDeltaMovement(new Vec3(dir.getStepX() * 0.4, 0, dir.getStepZ() * 0.4));
         moth.setHive(world, pos);

--- a/src/main/java/org/betterx/betterend/blocks/SilkMothNestBlock.java
+++ b/src/main/java/org/betterx/betterend/blocks/SilkMothNestBlock.java
@@ -149,13 +149,13 @@ public class SilkMothNestBlock extends BaseBlock implements RenderLayerProvider 
         if (!world.getBlockState(spawn).isAir()) {
             return;
         }
-        int count = world.getEntities(EndEntities.SILK_MOTH, new AABB(pos).inflate(16), (entity) -> {
+        int count = world.getEntities(EndEntities.SILK_MOTH.type(), new AABB(pos).inflate(16), (entity) -> {
             return true;
         }).size();
         if (count > 6) {
             return;
         }
-        SilkMothEntity moth = new SilkMothEntity(EndEntities.SILK_MOTH, world);
+        SilkMothEntity moth = new SilkMothEntity(EndEntities.SILK_MOTH.type(), world);
         moth.moveTo(spawn.getX() + 0.5, spawn.getY() + 0.5, spawn.getZ() + 0.5, dir.toYRot(), 0);
         moth.setDeltaMovement(new Vec3(dir.getStepX() * 0.4, 0, dir.getStepZ() * 0.4));
         moth.setHive(world, pos);

--- a/src/main/java/org/betterx/betterend/entity/DragonflyEntity.java
+++ b/src/main/java/org/betterx/betterend/entity/DragonflyEntity.java
@@ -209,6 +209,6 @@ public class DragonflyEntity extends DespawnableAnimal implements FlyingAnimal {
 
     @Override
     public AgeableMob getBreedOffspring(ServerLevel world, AgeableMob entity) {
-        return EndEntities.DRAGONFLY.create(world);
+        return EndEntities.DRAGONFLY.type().create(world);
     }
 }

--- a/src/main/java/org/betterx/betterend/entity/SilkMothEntity.java
+++ b/src/main/java/org/betterx/betterend/entity/SilkMothEntity.java
@@ -155,7 +155,7 @@ public class SilkMothEntity extends DespawnableAnimal implements FlyingAnimal {
 
     @Override
     public AgeableMob getBreedOffspring(ServerLevel world, AgeableMob entity) {
-        return EndEntities.SILK_MOTH.create(world);
+        return EndEntities.SILK_MOTH.type().create(world);
     }
 
     @Override

--- a/src/main/java/org/betterx/betterend/registry/EndEntities.java
+++ b/src/main/java/org/betterx/betterend/registry/EndEntities.java
@@ -1,6 +1,7 @@
 package org.betterx.betterend.registry;
 
 import org.betterx.bclib.api.v2.spawning.SpawnRuleBuilder;
+import org.betterx.bclib.entity.BCLEntityWrapper;
 import org.betterx.betterend.BetterEnd;
 import org.betterx.betterend.config.Configs;
 import org.betterx.betterend.entity.*;
@@ -17,7 +18,7 @@ import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRe
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 
 public class EndEntities {
-    public static final EntityType<DragonflyEntity> DRAGONFLY = register(
+    public static final BCLEntityWrapper<DragonflyEntity> DRAGONFLY = register(
             "dragonfly",
             MobCategory.AMBIENT,
             0.6F,
@@ -28,7 +29,7 @@ public class EndEntities {
             ColorUtil.color(32, 42, 176),
             ColorUtil.color(115, 225, 249)
     );
-    public static final EntityType<EndSlimeEntity> END_SLIME = register(
+    public static final BCLEntityWrapper<EndSlimeEntity> END_SLIME = register(
             "end_slime",
             MobCategory.MONSTER,
             2F,
@@ -39,7 +40,7 @@ public class EndEntities {
             ColorUtil.color(28, 28, 28),
             ColorUtil.color(99, 11, 99)
     );
-    public static final EntityType<EndFishEntity> END_FISH = register(
+    public static final BCLEntityWrapper<EndFishEntity> END_FISH = register(
             "end_fish",
             MobCategory.WATER_AMBIENT,
             0.5F,
@@ -50,7 +51,7 @@ public class EndEntities {
             ColorUtil.color(3, 50, 76),
             ColorUtil.color(120, 206, 255)
     );
-    public static final EntityType<ShadowWalkerEntity> SHADOW_WALKER = register(
+    public static final BCLEntityWrapper<ShadowWalkerEntity> SHADOW_WALKER = register(
             "shadow_walker",
             MobCategory.MONSTER,
             0.6F,
@@ -61,7 +62,7 @@ public class EndEntities {
             ColorUtil.color(30, 30, 30),
             ColorUtil.color(5, 5, 5)
     );
-    public static final EntityType<CubozoaEntity> CUBOZOA = register(
+    public static final BCLEntityWrapper<CubozoaEntity> CUBOZOA = register(
             "cubozoa",
             MobCategory.WATER_AMBIENT,
             0.6F,
@@ -72,7 +73,7 @@ public class EndEntities {
             ColorUtil.color(151, 77, 181),
             ColorUtil.color(93, 176, 238)
     );
-    public static final EntityType<SilkMothEntity> SILK_MOTH = register(
+    public static final BCLEntityWrapper<SilkMothEntity> SILK_MOTH = register(
             "silk_moth",
             MobCategory.AMBIENT,
             0.6F,
@@ -127,7 +128,7 @@ public class EndEntities {
         return type;
     }
 
-    private static <T extends Mob> EntityType<T> register(
+    private static <T extends Mob> BCLEntityWrapper<T> register(
             String name,
             MobCategory group,
             float width,
@@ -145,11 +146,10 @@ public class EndEntities {
                         ? EntityDimensions.fixed(width, height)
                         : EntityDimensions.scalable(width, height))
                 .build();
-        if (Configs.ENTITY_CONFIG.getBooleanRoot(id.getPath(), true)) {
-            FabricDefaultAttributeRegistry.register(type, attributes);
-            EndItems.registerEndEgg("spawn_egg_" + name, type, eggColor, dotsColor);
-            return Registry.register(Registry.ENTITY_TYPE, BetterEnd.makeID(name), type);
-        }
-        return type;
+        FabricDefaultAttributeRegistry.register(type, attributes);
+        EndItems.registerEndEgg("spawn_egg_" + name, type, eggColor, dotsColor);
+        Registry.register(Registry.ENTITY_TYPE, BetterEnd.makeID(name), type);
+
+        return new BCLEntityWrapper<>(type, Configs.ENTITY_CONFIG.getBooleanRoot(id.getPath(), true));
     }
 }

--- a/src/main/java/org/betterx/betterend/registry/EndEntitiesRenders.java
+++ b/src/main/java/org/betterx/betterend/registry/EndEntitiesRenders.java
@@ -32,12 +32,12 @@ public class EndEntitiesRenders {
     public static final ModelLayerLocation CRYSTALITE_BOOTS = registerMain("crystalite_boots");
 
     public static void register() {
-        register(EndEntities.DRAGONFLY, RendererEntityDragonfly::new);
-        register(EndEntities.END_SLIME, RendererEntityEndSlime::new);
-        register(EndEntities.END_FISH, RendererEntityEndFish::new);
-        register(EndEntities.SHADOW_WALKER, RendererEntityShadowWalker::new);
-        register(EndEntities.CUBOZOA, RendererEntityCubozoa::new);
-        register(EndEntities.SILK_MOTH, SilkMothEntityRenderer::new);
+        register(EndEntities.DRAGONFLY.type(), RendererEntityDragonfly::new);
+        register(EndEntities.END_SLIME.type(), RendererEntityEndSlime::new);
+        register(EndEntities.END_FISH.type(), RendererEntityEndFish::new);
+        register(EndEntities.SHADOW_WALKER.type(), RendererEntityShadowWalker::new);
+        register(EndEntities.CUBOZOA.type(), RendererEntityCubozoa::new);
+        register(EndEntities.SILK_MOTH.type(), SilkMothEntityRenderer::new);
 
         EntityModelLayerRegistry.registerModelLayer(DRAGONFLY_MODEL, DragonflyEntityModel::getTexturedModelData);
         EntityModelLayerRegistry.registerModelLayer(

--- a/src/main/java/org/betterx/betterend/registry/EndItems.java
+++ b/src/main/java/org/betterx/betterend/registry/EndItems.java
@@ -277,9 +277,9 @@ public class EndItems {
     public final static Item END_FISH_COOKED = registerEndFood("end_fish_cooked", Foods.COOKED_SALMON);
     public final static Item BUCKET_END_FISH = registerEndItem(
             "bucket_end_fish",
-            new EndBucketItem(EndEntities.END_FISH)
+            new EndBucketItem(EndEntities.END_FISH.type())
     );
-    public final static Item BUCKET_CUBOZOA = registerEndItem("bucket_cubozoa", new EndBucketItem(EndEntities.CUBOZOA));
+    public final static Item BUCKET_CUBOZOA = registerEndItem("bucket_cubozoa", new EndBucketItem(EndEntities.CUBOZOA.type()));
     public final static Item SWEET_BERRY_JELLY = registerEndFood("sweet_berry_jelly", 8, 0.7F);
     public final static Item SHADOW_BERRY_JELLY = registerEndFood(
             "shadow_berry_jelly",


### PR DESCRIPTION
I wanted to disable some mob and it crashed. If an entity is disabled in configs, it is not registered and the biome builder throws an error.

I noticed that in BetterNether works fine so I decided to copy the same approach.