### PR TITLE
Update Cardinal Components repo address

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,12 @@ repositories {
     maven { url 'https://jitpack.io' }
     maven { url 'https://maven.terraformersmc.com/releases' }
     maven { url = "https://maven.terraformersmc.com/" }
-    maven { url "https://ladysnake.jfrog.io/artifactory/mods" }
     maven { url = "https://dvs1.progwml6.com/files/maven/" }
     maven { url = "https://modmaven.dev" }
+    maven {
+        name = 'Ladysnake Mods'
+        url = 'https://maven.ladysnake.org/releases'
+    }
     exclusiveContent {
         forRepository {
             maven {


### PR DESCRIPTION
Quoting [LadySnake's repo](https://github.com/Ladysnake/Cardinal-Components-API/blob/3c2c524b3eb481405d65f8bd65096692834a1ae7/README.md?plain=1#L1-L4):

> **As Jfrog has ended their free service for OSS projects, we had to move the maven repository before the 1st of July 2023.**

This PR follows their instructions to replace the (now defunct) repo address with the new one so that it is once again possible to build BetterEnd.