### PR TITLE
Fix return portal position calculation for dragon respawn

### DIFF
--- a/src/main/java/org/betterx/betterend/mixin/common/EndDragonFightMixin.java
+++ b/src/main/java/org/betterx/betterend/mixin/common/EndDragonFightMixin.java
@@ -1,6 +1,5 @@
 package org.betterx.betterend.mixin.common;
 
-import java.util.Arrays;
 import org.betterx.bclib.util.BlocksHelper;
 import org.betterx.betterend.world.generator.GeneratorOptions;
 
@@ -69,11 +68,11 @@ public class EndDragonFightMixin {
             }
 
             Vec3 center = new Vec3(
-                Math.floor(portalLocation.getX()),
+                portalLocation.getX(),
                 0,
-                Math.floor(portalLocation.getZ())
+                portalLocation.getZ()
             );
-            LOGGER.debug("Assuming portal is centered at {}", center);
+            LOGGER.debug("Checking around portal centered at {}", center);
 
             List<EndCrystal> crystals = Lists.newArrayList();
             for (Direction dir : BlocksHelper.HORIZONTAL) {


### PR DESCRIPTION
Fixes #327 by ~~_explicitly flooring_~~ removing the (now)-unnecessary translations applied to the X and Z coordinates of `this.portalLocation`

## Validation Performed

- [x] Successfully respawned the dragon in an existing BetterX world (that I think was originally created in Minecraft 1.18)
- [x] Successfully respawned the dragon in a _brand new_ BetterX world created in Minecraft 1.20.4 with BCLib 3.30.1 and a build of this branch of BetterEnd

In both cases, the log message read:

```
Assuming portal is centered at (0.0, 0.0, 0.0)
```

though, so if there are scenarios where the portal could be elsewhere, I haven't confirmed that to be working.

Also note that I'm only checking from y=0 to y=255 (rather than -255 to 255) because I don't think there's any scenario in which the portal will generate at a negative y level (if I'm wrong, feel free to change back!)

---

Stepping back, I realize that this actually could have been a two-line change to just remove the +/- 1 from https://github.com/quiqueck/BetterEnd/blob/35c56c534232ded7bbb2c97b00f9e7fc221dddf4/src/main/java/org/betterx/betterend/mixin/common/EndDragonFightMixin.java#L77-L78

so feel free to just do that instead and close this PR.