### PR TITLE
Fix End Veil enchantment component registration

### DIFF
--- a/src/main/java/org/betterx/betterend/registry/EndEnchantments.java
+++ b/src/main/java/org/betterx/betterend/registry/EndEnchantments.java
@@ -1,5 +1,9 @@
 package org.betterx.betterend.registry;
 
+import java.util.function.UnaryOperator;
+import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponentType.Builder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import org.betterx.betterend.BetterEnd;
 import org.betterx.wover.enchantment.api.EnchantmentKey;
 import org.betterx.wover.enchantment.api.EnchantmentManager;
@@ -11,11 +15,14 @@ public class EndEnchantments {
     public final static EnchantmentKey END_VEIL = EnchantmentManager.createKey(BetterEnd.C.mk("end_veil"));
 
 
-    public static final DataComponentType<Unit> END_VEIL_STATE = EnchantmentManager.registerDataComponent(
-            BetterEnd.C.mk("end_veil"),
+    public static final DataComponentType<Unit> END_VEIL_STATE = registerEnchantment(
+            BetterEnd.C.mk("end_veil_state").toString(),
             (builder) -> builder.persistent(Unit.CODEC)
     );
 
-    public static void register() {
+    private static DataComponentType<Unit> registerEnchantment(String string, UnaryOperator<Builder<Unit>> unaryOperator) {
+        return Registry.register(BuiltInRegistries.ENCHANTMENT_EFFECT_COMPONENT_TYPE, string, unaryOperator.apply(DataComponentType.builder()).build());
     }
+
+    public static void register() {}
 }

--- a/src/main/resources/data/betterend/enchantment/end_veil.json
+++ b/src/main/resources/data/betterend/enchantment/end_veil.json
@@ -4,18 +4,7 @@
     "translate": "enchantment.betterend.end_veil"
   },
   "effects": {
-    "minecraft:tick": [
-      {
-        "effect": {
-          "type": "minecraft:apply_mob_effect",
-          "min_duration": 1.0,
-          "max_duration": 1.5,
-          "min_amplifier": 1.0,
-          "max_amplifier": 1.0,
-          "to_apply": "betterend:end_veil"
-        }
-      }
-    ]
+    "betterend:end_veil_state": {}
   },
   "max_cost": {
     "base": 41,


### PR DESCRIPTION
In 7721b7594cb9f1fada0c07b18805a4205117a229 I naïvely implemented the End Veil enchantment as applying the potion effect to the player for the duration they were wearing the end veil enchanted item.

While functionally workable, that produced a lot of particles as well as a continuously flashing icon in the corner of the screen.

This commit fixes the end veil component's registration, cribbing directly from the Curse of Binding enchantment.

@frankbauer, I'm guessing, however, that you'll want to move this implementation [upstream](https://github.com/quiqueck/WorldWeaver/blob/8861dbf39c85cdafbaf2caab1783d11c26d78f44/wover-item-api/src/main/java/org/betterx/wover/enchantment/api/EnchantmentManager.java) (read: the appropriate registry is actually `BuiltInRegistries.ENCHANTMENT_EFFECT_COMPONENT_TYPE`, and I'm unsure if you want to _replace_ the existing method as unneeded or simply add a new one).