### PR TITLE
Fix bug that the end stone smelter does not open the menu.

### DIFF
--- a/src/main/java/org/betterx/betterend/blocks/EndStoneSmelter.java
+++ b/src/main/java/org/betterx/betterend/blocks/EndStoneSmelter.java
@@ -55,15 +55,8 @@ public class EndStoneSmelter extends BaseBlockWithEntity.Stone implements Alloyi
         registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH).setValue(LIT, false));
     }
 
-    @SuppressWarnings("deprecation")
-    public InteractionResult use(
-            BlockState state,
-            Level world,
-            BlockPos pos,
-            Player player,
-            InteractionHand hand,
-            BlockHitResult hit
-    ) {
+    @Override
+    protected InteractionResult useWithoutItem(BlockState state, Level world, BlockPos pos, Player player, BlockHitResult hit) {
         if (world.isClientSide) {
             return InteractionResult.SUCCESS;
         } else {

--- a/src/main/java/org/betterx/betterend/client/gui/EndStoneSmelterScreen.java
+++ b/src/main/java/org/betterx/betterend/client/gui/EndStoneSmelterScreen.java
@@ -21,7 +21,11 @@ import net.fabricmc.api.Environment;
 @Environment(EnvType.CLIENT)
 public class EndStoneSmelterScreen extends AbstractContainerScreen<EndStoneSmelterMenu> implements RecipeUpdateListener {
 
-    private final static ResourceLocation RECIPE_BUTTON_TEXTURE = ResourceLocation.withDefaultNamespace("textures/gui/recipe_button.png");
+    public static final WidgetSprites RECIPE_BUTTON_SPRITES = new WidgetSprites(
+            ResourceLocation.withDefaultNamespace("recipe_book/button"),
+            ResourceLocation.withDefaultNamespace("recipe_book/button_highlighted")
+    );
+
     private final static ResourceLocation BACKGROUND_TEXTURE = BetterEnd.C.mk("textures/gui/smelter_gui.png");
 
     public final EndStoneSmelterRecipeBookScreen recipeBook;
@@ -42,7 +46,7 @@ public class EndStoneSmelterScreen extends AbstractContainerScreen<EndStoneSmelt
                 height / 2 - 49,
                 20,
                 18,
-                new WidgetSprites(RECIPE_BUTTON_TEXTURE, RECIPE_BUTTON_TEXTURE),
+                RECIPE_BUTTON_SPRITES,
                 (buttonWidget) -> {
                     recipeBook.initVisuals();
                     recipeBook.toggleVisibility();


### PR DESCRIPTION
Fixed bug that EndStoneSmelter doesn't work, i.e. it's not possible to open the menu and use it. 

In 1.21 there is no old "use" method anymore, so new "useWithoutItem" is implemented instead of the old one.