### PR TITLE
Fix Completely non functional armor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ artifacts {
     dev jar
 }
 
-// apply from: "helper.gradle"
+apply from: "helper.gradle"
 
 allprojects {
     // Allow 400 errors.

--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ artifacts {
     dev jar
 }
 
-apply from: "helper.gradle"
+// apply from: "helper.gradle"
 
 allprojects {
     // Allow 400 errors.

--- a/src/main/generated/data/betterend/recipe/crystalite_boots.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_boots.json
@@ -19,34 +19,7 @@
   },
   "input": {
     "item": {
-      "item": "betterend:terminite_boots",
-      "nbt": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": [
-            {
-              "type": "minecraft:generic.attack_damage",
-              "amount": 8.0,
-              "id": "minecraft:base_attack_damage",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_speed",
-              "amount": -3.200000047683716,
-              "id": "minecraft:base_attack_speed",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_knockback",
-              "amount": 0.30000001192092896,
-              "id": "betterend:base_knockback",
-              "operation": "add_value",
-              "slot": "mainhand"
-            }
-          ]
-        }
-      }
+      "item": "betterend:terminite_boots"
     }
   },
   "result": {
@@ -56,17 +29,17 @@
         "modifiers": [
           {
             "type": "minecraft:generic.armor",
-            "amount": 6.400000095367432,
-            "id": "betterend:armor_boost",
+            "amount": 3.0,
+            "id": "betterend:armor_boostboots",
             "operation": "add_value",
-            "slot": "chest"
+            "slot": "feet"
           },
           {
             "type": "minecraft:generic.armor_toughness",
-            "amount": 0.9600000381469727,
-            "id": "betterend:toughness_boost",
+            "amount": 1.2000000476837158,
+            "id": "betterend:toughness_boostboots",
             "operation": "add_value",
-            "slot": "chest"
+            "slot": "feet"
           }
         ]
       }

--- a/src/main/generated/data/betterend/recipe/crystalite_boots.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_boots.json
@@ -30,14 +30,14 @@
           {
             "type": "minecraft:generic.armor",
             "amount": 3.0,
-            "id": "betterend:armor_boostboots",
+            "id": "betterend:armor_boost_boots",
             "operation": "add_value",
             "slot": "feet"
           },
           {
             "type": "minecraft:generic.armor_toughness",
             "amount": 1.2000000476837158,
-            "id": "betterend:toughness_boostboots",
+            "id": "betterend:toughness_boost_boots",
             "operation": "add_value",
             "slot": "feet"
           }

--- a/src/main/generated/data/betterend/recipe/crystalite_chestplate.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_chestplate.json
@@ -40,14 +40,14 @@
           {
             "type": "minecraft:generic.armor",
             "amount": 8.0,
-            "id": "betterend:armor_boostchestplate",
+            "id": "betterend:armor_boost_chestplate",
             "operation": "add_value",
             "slot": "chest"
           },
           {
             "type": "minecraft:generic.armor_toughness",
             "amount": 1.2000000476837158,
-            "id": "betterend:toughness_boostchestplate",
+            "id": "betterend:toughness_boost_chestplate",
             "operation": "add_value",
             "slot": "chest"
           }

--- a/src/main/generated/data/betterend/recipe/crystalite_chestplate.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_chestplate.json
@@ -29,34 +29,7 @@
   },
   "input": {
     "item": {
-      "item": "betterend:terminite_chestplate",
-      "nbt": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": [
-            {
-              "type": "minecraft:generic.attack_damage",
-              "amount": 8.0,
-              "id": "minecraft:base_attack_damage",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_speed",
-              "amount": -3.200000047683716,
-              "id": "minecraft:base_attack_speed",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_knockback",
-              "amount": 0.30000001192092896,
-              "id": "betterend:base_knockback",
-              "operation": "add_value",
-              "slot": "mainhand"
-            }
-          ]
-        }
-      }
+      "item": "betterend:terminite_chestplate"
     }
   },
   "result": {
@@ -66,15 +39,15 @@
         "modifiers": [
           {
             "type": "minecraft:generic.armor",
-            "amount": 6.400000095367432,
-            "id": "betterend:armor_boost",
+            "amount": 8.0,
+            "id": "betterend:armor_boostchestplate",
             "operation": "add_value",
             "slot": "chest"
           },
           {
             "type": "minecraft:generic.armor_toughness",
-            "amount": 0.9600000381469727,
-            "id": "betterend:toughness_boost",
+            "amount": 1.2000000476837158,
+            "id": "betterend:toughness_boostchestplate",
             "operation": "add_value",
             "slot": "chest"
           }

--- a/src/main/generated/data/betterend/recipe/crystalite_elytra.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_elytra.json
@@ -55,14 +55,14 @@
           {
             "type": "minecraft:generic.armor",
             "amount": 6.0,
-            "id": "betterend:armor_boostchestplate",
+            "id": "betterend:armor_boost_chestplate",
             "operation": "add_value",
             "slot": "chest"
           },
           {
             "type": "minecraft:generic.armor_toughness",
             "amount": 0.9600000381469727,
-            "id": "betterend:toughness_boostchestplate",
+            "id": "betterend:toughness_boost_chestplate",
             "operation": "add_value",
             "slot": "chest"
           },

--- a/src/main/generated/data/betterend/recipe/crystalite_elytra.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_elytra.json
@@ -54,15 +54,15 @@
         "modifiers": [
           {
             "type": "minecraft:generic.armor",
-            "amount": 6.400000095367432,
-            "id": "betterend:armor_boost",
+            "amount": 6.0,
+            "id": "betterend:armor_boostchestplate",
             "operation": "add_value",
             "slot": "chest"
           },
           {
             "type": "minecraft:generic.armor_toughness",
             "amount": 0.9600000381469727,
-            "id": "betterend:toughness_boost",
+            "id": "betterend:toughness_boostchestplate",
             "operation": "add_value",
             "slot": "chest"
           },
@@ -71,7 +71,7 @@
             "amount": 0.5,
             "id": "betterend:base_knockback_resistance",
             "operation": "add_value",
-            "slot": "mainhand"
+            "slot": "chest"
           }
         ]
       }

--- a/src/main/generated/data/betterend/recipe/crystalite_helmet.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_helmet.json
@@ -19,34 +19,7 @@
   },
   "input": {
     "item": {
-      "item": "betterend:terminite_helmet",
-      "nbt": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": [
-            {
-              "type": "minecraft:generic.attack_damage",
-              "amount": 8.0,
-              "id": "minecraft:base_attack_damage",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_speed",
-              "amount": -3.200000047683716,
-              "id": "minecraft:base_attack_speed",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_knockback",
-              "amount": 0.30000001192092896,
-              "id": "betterend:base_knockback",
-              "operation": "add_value",
-              "slot": "mainhand"
-            }
-          ]
-        }
-      }
+      "item": "betterend:terminite_helmet"
     }
   },
   "result": {
@@ -56,17 +29,17 @@
         "modifiers": [
           {
             "type": "minecraft:generic.armor",
-            "amount": 6.400000095367432,
-            "id": "betterend:armor_boost",
+            "amount": 3.0,
+            "id": "betterend:armor_boosthelmet",
             "operation": "add_value",
-            "slot": "chest"
+            "slot": "head"
           },
           {
             "type": "minecraft:generic.armor_toughness",
-            "amount": 0.9600000381469727,
-            "id": "betterend:toughness_boost",
+            "amount": 1.2000000476837158,
+            "id": "betterend:toughness_boosthelmet",
             "operation": "add_value",
-            "slot": "chest"
+            "slot": "head"
           },
           {
             "type": "betterend:generic.blindness_resistance",

--- a/src/main/generated/data/betterend/recipe/crystalite_helmet.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_helmet.json
@@ -30,14 +30,14 @@
           {
             "type": "minecraft:generic.armor",
             "amount": 3.0,
-            "id": "betterend:armor_boosthelmet",
+            "id": "betterend:armor_boost_helmet",
             "operation": "add_value",
             "slot": "head"
           },
           {
             "type": "minecraft:generic.armor_toughness",
             "amount": 1.2000000476837158,
-            "id": "betterend:toughness_boosthelmet",
+            "id": "betterend:toughness_boost_helmet",
             "operation": "add_value",
             "slot": "head"
           },

--- a/src/main/generated/data/betterend/recipe/crystalite_leggings.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_leggings.json
@@ -24,34 +24,7 @@
   },
   "input": {
     "item": {
-      "item": "betterend:terminite_leggings",
-      "nbt": {
-        "minecraft:attribute_modifiers": {
-          "modifiers": [
-            {
-              "type": "minecraft:generic.attack_damage",
-              "amount": 8.0,
-              "id": "minecraft:base_attack_damage",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_speed",
-              "amount": -3.200000047683716,
-              "id": "minecraft:base_attack_speed",
-              "operation": "add_value",
-              "slot": "mainhand"
-            },
-            {
-              "type": "minecraft:generic.attack_knockback",
-              "amount": 0.30000001192092896,
-              "id": "betterend:base_knockback",
-              "operation": "add_value",
-              "slot": "mainhand"
-            }
-          ]
-        }
-      }
+      "item": "betterend:terminite_leggings"
     }
   },
   "result": {
@@ -61,24 +34,24 @@
         "modifiers": [
           {
             "type": "minecraft:generic.armor",
-            "amount": 6.400000095367432,
-            "id": "betterend:armor_boost",
+            "amount": 6.0,
+            "id": "betterend:armor_boostleggings",
             "operation": "add_value",
-            "slot": "chest"
+            "slot": "legs"
           },
           {
             "type": "minecraft:generic.armor_toughness",
-            "amount": 0.9600000381469727,
-            "id": "betterend:toughness_boost",
+            "amount": 1.2000000476837158,
+            "id": "betterend:toughness_boostleggings",
             "operation": "add_value",
-            "slot": "chest"
+            "slot": "legs"
           },
           {
             "type": "minecraft:generic.max_health",
             "amount": 4.0,
             "id": "betterend:max_health_boost",
             "operation": "add_value",
-            "slot": "head"
+            "slot": "legs"
           }
         ]
       }

--- a/src/main/generated/data/betterend/recipe/crystalite_leggings.json
+++ b/src/main/generated/data/betterend/recipe/crystalite_leggings.json
@@ -35,14 +35,14 @@
           {
             "type": "minecraft:generic.armor",
             "amount": 6.0,
-            "id": "betterend:armor_boostleggings",
+            "id": "betterend:armor_boost_leggings",
             "operation": "add_value",
             "slot": "legs"
           },
           {
             "type": "minecraft:generic.armor_toughness",
             "amount": 1.2000000476837158,
-            "id": "betterend:toughness_boostleggings",
+            "id": "betterend:toughness_boost_leggings",
             "operation": "add_value",
             "slot": "legs"
           },

--- a/src/main/java/org/betterx/betterend/complexmaterials/MetalMaterial.java
+++ b/src/main/java/org/betterx/betterend/complexmaterials/MetalMaterial.java
@@ -215,21 +215,38 @@ public class MetalMaterial implements MaterialManager.Material {
         forgedPlate = EndItems.registerEndItem(name + "_forged_plate");
         helmet = EndItems.registerEndItem(
                 name + "_helmet",
-                new EndArmorItem(armor, ArmorSlot.HELMET_SLOT, itemSettings)
+                new EndArmorItem(
+                        armor,
+                        ArmorSlot.HELMET_SLOT,
+                        EndArmorItem.createDefaultEndArmorSettings(ArmorSlot.HELMET_SLOT, armor))
         );
         chestplate = EndItems.registerEndItem(
                 name + "_chestplate",
-                new EndArmorItem(armor, ArmorSlot.CHESTPLATE_SLOT, itemSettings)
+                new EndArmorItem(
+                        armor,
+                        ArmorSlot.CHESTPLATE_SLOT,
+                        EndArmorItem.createDefaultEndArmorSettings(ArmorSlot.CHESTPLATE_SLOT, armor))
         );
         leggings = EndItems.registerEndItem(
                 name + "_leggings",
-                new EndArmorItem(armor, ArmorSlot.LEGGINGS_SLOT, itemSettings)
+                new EndArmorItem(
+                        armor,
+                        ArmorSlot.LEGGINGS_SLOT,
+                        EndArmorItem.createDefaultEndArmorSettings(ArmorSlot.LEGGINGS_SLOT, armor))
         );
-        boots = EndItems.registerEndItem(name + "_boots", new EndArmorItem(armor, ArmorSlot.BOOTS_SLOT, itemSettings));
+        boots = EndItems.registerEndItem(
+                name + "_boots",
+                new EndArmorItem(
+                        armor,
+                        ArmorSlot.BOOTS_SLOT,
+                        EndArmorItem.createDefaultEndArmorSettings(ArmorSlot.BOOTS_SLOT, armor)));
 
         anvilBlock = EndBlocks.registerBlock(
                 name + "_anvil",
-                new EndAnvilBlock(this, block.defaultMapColor(), anvilLevel)
+                new EndAnvilBlock(
+                        this,
+                        block.defaultMapColor(),
+                        anvilLevel)
         );
 
         MaterialManager.register(this);

--- a/src/main/java/org/betterx/betterend/item/CrystaliteLeggings.java
+++ b/src/main/java/org/betterx/betterend/item/CrystaliteLeggings.java
@@ -21,7 +21,7 @@ public class CrystaliteLeggings extends CrystaliteArmor {
                                 4.0,
                                 AttributeModifier.Operation.ADD_VALUE
                         ),
-                        EquipmentSlotGroup.HEAD
+                        EquipmentSlotGroup.LEGS
                 ).build()
         );
     }

--- a/src/main/java/org/betterx/betterend/item/EndArmorItem.java
+++ b/src/main/java/org/betterx/betterend/item/EndArmorItem.java
@@ -15,6 +15,8 @@ import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 
+import java.util.Arrays;
+
 public class EndArmorItem extends ArmorItem implements ItemModelProvider {
     public static final ResourceLocation BASE_BLINDNESS_RESISTANCE = BetterEnd.C.mk("base_blindness_resistance");
     public static final ResourceLocation BASE_KNOCKBACK_RESISTANCE = BetterEnd.C.mk("base_knockback_resistance");
@@ -36,10 +38,10 @@ public class EndArmorItem extends ArmorItem implements ItemModelProvider {
             ArmorTier tier
     ) {
         return startAttributeBuilder(slot, tier,
-                EndArmorTier.CRYSTALITE.armorMaterial
+                tier.armorMaterial
                         .value()
                         .getDefense(slot.armorType),
-                EndArmorTier.CRYSTALITE.armorMaterial
+                tier.armorMaterial
                         .value()
                         .toughness(),
                 0.0f
@@ -58,24 +60,20 @@ public class EndArmorItem extends ArmorItem implements ItemModelProvider {
                 .add(
                         Attributes.ARMOR,
                         new AttributeModifier(
-                                ARMOR_BOOST,
-                                EndArmorTier.CRYSTALITE.armorMaterial
-                                        .value()
-                                        .getDefense(Type.CHESTPLATE) / 1.25f,
+                                ARMOR_BOOST.withSuffix(slot.name),
+                                defense,
                                 AttributeModifier.Operation.ADD_VALUE
                         ),
-                        EquipmentSlotGroup.CHEST
+                        EquipmentSlotGroup.bySlot(slot.armorType.getSlot())
                 )
                 .add(
                         Attributes.ARMOR_TOUGHNESS,
                         new AttributeModifier(
-                                TOUGHNESS_BOOST,
-                                EndArmorTier.CRYSTALITE.armorMaterial
-                                        .value()
-                                        .toughness() / 1.25f,
+                                TOUGHNESS_BOOST.withSuffix(slot.name),
+                                toughness,
                                 AttributeModifier.Operation.ADD_VALUE
                         ),
-                        EquipmentSlotGroup.CHEST
+                        EquipmentSlotGroup.bySlot(slot.armorType.getSlot())
                 );
 
         if (knockbackResistance > 0.0f) {
@@ -86,7 +84,7 @@ public class EndArmorItem extends ArmorItem implements ItemModelProvider {
                             knockbackResistance,
                             AttributeModifier.Operation.ADD_VALUE
                     ),
-                    EquipmentSlotGroup.MAINHAND
+                    EquipmentSlotGroup.bySlot(slot.armorType.getSlot())
             );
         }
 

--- a/src/main/java/org/betterx/betterend/item/EndArmorItem.java
+++ b/src/main/java/org/betterx/betterend/item/EndArmorItem.java
@@ -60,7 +60,7 @@ public class EndArmorItem extends ArmorItem implements ItemModelProvider {
                 .add(
                         Attributes.ARMOR,
                         new AttributeModifier(
-                                ARMOR_BOOST.withSuffix(slot.name),
+                                ARMOR_BOOST.withSuffix("_"+slot.name),
                                 defense,
                                 AttributeModifier.Operation.ADD_VALUE
                         ),
@@ -69,7 +69,7 @@ public class EndArmorItem extends ArmorItem implements ItemModelProvider {
                 .add(
                         Attributes.ARMOR_TOUGHNESS,
                         new AttributeModifier(
-                                TOUGHNESS_BOOST.withSuffix(slot.name),
+                                TOUGHNESS_BOOST.withSuffix("_"+slot.name),
                                 toughness,
                                 AttributeModifier.Operation.ADD_VALUE
                         ),


### PR DESCRIPTION
- Make Armor look up its slot on creation
- Make Knockback resistance no longer hardcoded to main hand
- Make Different Pieces or Armor give their respective armor Values instead of an average

This does NOT fix Crstalite Armor that was already crafted due to how infusion works.

Affected Pieces of equipment:
- Terminite Armor
- Thallasium Armor
- Crystal Armor
- Crystal Elytra

closes #514 