### PR TITLE
Fix elytra trinket integration

### DIFF
--- a/src/main/java/org/betterx/betterend/integration/trinkets/Elytra.java
+++ b/src/main/java/org/betterx/betterend/integration/trinkets/Elytra.java
@@ -1,24 +1,24 @@
 package org.betterx.betterend.integration.trinkets;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.betterx.bclib.items.elytra.BCLElytraItem;
 import org.betterx.bclib.items.elytra.BCLElytraUtils;
 
+import dev.emi.trinkets.api.SlotReference;
+import dev.emi.trinkets.api.TrinketComponent;
+import dev.emi.trinkets.api.TrinketsApi;
+import net.fabricmc.fabric.api.entity.event.v1.EntityElytraEvents;
+import net.fabricmc.fabric.api.entity.event.v1.FabricElytraItem;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ElytraItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-
-import net.fabricmc.fabric.api.entity.event.v1.EntityElytraEvents;
-import net.fabricmc.fabric.api.entity.event.v1.FabricElytraItem;
-
-import dev.emi.trinkets.api.SlotReference;
-import dev.emi.trinkets.api.TrinketComponent;
-import dev.emi.trinkets.api.TrinketsApi;
-
-import java.util.List;
-import java.util.Optional;
 
 public class Elytra {
     private static boolean isElytra(ItemStack stack) {
@@ -42,18 +42,25 @@ public class Elytra {
         };
 
         BCLElytraUtils.onBreak = (entity, chestStack) -> {
-            Optional<TrinketComponent> oTrinketComponent = TrinketsApi.getTrinketComponent(entity);
-            if (oTrinketComponent.isPresent()) {
-                List<Tuple<SlotReference, ItemStack>> equipped =
-                        oTrinketComponent.get().getEquipped(Elytra::isElytra);
+    		if(entity.getItemBySlot(EquipmentSlot.CHEST) == chestStack) {
+    			chestStack.hurtAndBreak(1, entity, EquipmentSlot.CHEST);
+    		} else {
+                Optional<TrinketComponent> oTrinketComponent = TrinketsApi.getTrinketComponent(entity);
+    			if (entity.level() instanceof ServerLevel serverLevel && oTrinketComponent.isPresent()) {
+                    List<Tuple<SlotReference, ItemStack>> equipped =
+                            oTrinketComponent.get().getEquipped(Elytra::isElytra);
 
-                for (Tuple<SlotReference, ItemStack> slot : equipped) {
-                    ItemStack slotStack = slot.getB();
-                    if (slotStack == chestStack) {
-                        TrinketsApi.onTrinketBroken(slotStack, slot.getA(), entity);
-                    }
-                }
-            }
+                    for (Tuple<SlotReference, ItemStack> slot : equipped) {
+                        ItemStack slotStack = slot.getB();
+                        if (slotStack == chestStack) {
+                        	chestStack.hurtAndBreak(
+        						1, serverLevel, entity instanceof ServerPlayer serverPlayer ? serverPlayer : null, item -> TrinketsApi.onTrinketBroken(slotStack, slot.getA(), entity)
+        					);
+                            break;
+                        }
+    	            }
+    			}
+    		}
         };
 
         EntityElytraEvents.CUSTOM.register(Elytra::useElytraTrinket);


### PR DESCRIPTION
Fixes several bugs with the elytra damage handler registered as part of Trinkets integration.

Previously, BCLib Elytras would not lose any durability ever (even when equipped on the player's chest) and would always play the "item broken" sound effect when equipped in a trinket slot (even though the item has not broken, or even lost any durability).

This pull request fixes both of the above bugs.