### PR TITLE
Fix crash with Dye Depot

### DIFF
--- a/src/main/java/org/betterx/betterend/complexmaterials/ColoredMaterial.java
+++ b/src/main/java/org/betterx/betterend/complexmaterials/ColoredMaterial.java
@@ -37,25 +37,27 @@ public class ColoredMaterial {
     ) {
         String id = BuiltInRegistries.BLOCK.getKey(source).getPath();
         colors.forEach((color, name) -> {
-            String blockName = id + "_" + name;
-            Block block = constructor.apply(FabricBlockSettings.copyOf(source).mapColor(MapColor.COLOR_BLACK));
-            EndBlocks.registerBlock(blockName, block);
-            if (craftEight) {
-                BCLRecipeBuilder.crafting(BetterEnd.makeID(blockName), block)
-                                .setOutputCount(8)
-                                .setShape("###", "#D#", "###")
-                                .addMaterial('#', source)
-                                .addMaterial('D', dyes.get(color))
-                                .build();
-            } else {
-                BCLRecipeBuilder.crafting(BetterEnd.makeID(blockName), block)
-                                .setList("#D")
-                                .addMaterial('#', source)
-                                .addMaterial('D', dyes.get(color))
-                                .build();
+            if(dyes.containsKey(color) && dyes.get(color) != null){
+                String blockName = id + "_" + name;
+                Block block = constructor.apply(FabricBlockSettings.copyOf(source).mapColor(MapColor.COLOR_BLACK));
+                EndBlocks.registerBlock(blockName, block);
+                if (craftEight) {
+                    BCLRecipeBuilder.crafting(BetterEnd.makeID(blockName), block)
+                                    .setOutputCount(8)
+                                    .setShape("###", "#D#", "###")
+                                    .addMaterial('#', source)
+                                    .addMaterial('D', dyes.get(color))
+                                    .build();
+                } else {
+                    BCLRecipeBuilder.crafting(BetterEnd.makeID(blockName), block)
+                                    .setList("#D")
+                                    .addMaterial('#', source)
+                                    .addMaterial('D', dyes.get(color))
+                                    .build();
+                }
+                this.colors.put(color, block);
+                BlocksHelper.addBlockColor(block, color);
             }
-            this.colors.put(color, block);
-            BlocksHelper.addBlockColor(block, color);
         });
     }
 


### PR DESCRIPTION
The game will crash on launch when both Dye Depot and BetterEnd are installed. See related issues here:
- https://github.com/quiqueck/BetterEnd/issues/515
- https://github.com/quiqueck/BetterEnd/issues/436
- https://github.com/quiqueck/BetterEnd/issues/374
- https://github.com/N1nn1/dye_depot/issues/59
- https://github.com/N1nn1/dye_depot/issues/1

This PR is a quick and dirty fix for the crash. 
It does NOT add any special compatibility (i.e.: BetterEnd items with Dye Depot colors). It just fixes the crash so that you can play with both mods installed.