### PR TITLE
[Fix] End portals: guard EndPortals.getColor against invalid portal state

### DIFF
--- a/src/main/java/org/betterx/betterend/registry/EndPortals.java
+++ b/src/main/java/org/betterx/betterend/registry/EndPortals.java
@@ -83,6 +83,9 @@ public class EndPortals {
     }
 
     public static int getColor(int state) {
+        if (state < 0 || state >= portals.length) {
+            return portals[0].color;
+        }
         return portals[state].color;
     }
 


### PR DESCRIPTION
### Root cause
`EndPortals.getCount()` returns `max(portals.length - 1, 1)`, so the `EndPortalBlock.PORTAL` block state allows values `0..getCount()`. When `portals.json` only defines 1 portal, a block in state `portal=1` (set via debug stick or generated by worldgen) makes `EndPortals.getColor(1)` index `portals[1]` directly, throwing `ArrayIndexOutOfBoundsException` on the render thread. The crash is renderer-agnostic (Sodium and vanilla both affected).

`getColor` is the only method in the class without bounds guarding — `getWorld` and `getWorldId` already fall back to the overworld.

### Fix
Guard `getColor` the same way as `getWorld`/`getWorldId`: fall back to the first portal (overworld, white) when `state` is out of bounds.

```java
public static int getColor(int state) {
    if (state < 0 || state >= portals.length) {
        return portals[0].color;
    }
    return portals[state].color;
}
```

General root-cause fix: covers every render path and every MC version (1.20.4 in #527 included).

Fixes #527